### PR TITLE
fix: Handle loading env files and dynamic URL for local and dev env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN cd client && npm ci --only=production
 
 
 # Copy backend files and directories
-COPY server.js redisClient.js trendUploader.js ./
+COPY server.js redisClient.js trendUploader.js loadEnv.js ./
 COPY api/ ./api/
 COPY config/ ./config/
 COPY controllers/ ./controllers/

--- a/client/src/utils/urlHelper.js
+++ b/client/src/utils/urlHelper.js
@@ -15,17 +15,14 @@ export const getFullIconUrl = (iconUrl) => {
   if (!value) return '';
   if (isAbsoluteUrl(value)) return value;//leave absolute urls alone (cloudinary/r2/full urls/etc.)
 
-  if (import.meta.env.DEV && !ASSET_CDN_BASE) {
-    return value;//in dev keep local relative assets unless you explicitly set a cdn base
-  }
   if (ASSET_CDN_BASE) {
     return joinUrl(ASSET_CDN_BASE, value);// if cdn base exists, use it in prod (and optionally dev)
   }
-  return FRONTEND_BASE_URL ? joinUrl(FRONTEND_BASE_URL, value) : value;// final fallback to frontend base if needed
+  return value.startsWith('/') ? value : `/${value}`;
 };// icons/assets url
 
 export const getFullTrendUrl = (slug) =>
-  `${FRONTEND_BASE_URL}/dashboard/trend/${slug}`;//trend detail page url stays on the app domain
+  `/dashboard/trend/${slug}`;//trend detail page url stays on the app domain
 
 export const githubUrl = () => {
   return GITHUB_URL;

--- a/loadEnv.js
+++ b/loadEnv.js
@@ -1,0 +1,15 @@
+import * as dotenv from 'dotenv';
+import path from 'path';
+
+// Determine the environment
+const env = process.env.NODE_ENV || 'development';
+
+// Explicitly load .env.<environment>
+const envPath = path.resolve(process.cwd(), `.env.${env}`);
+const result = dotenv.config({ path: envPath });
+
+if (result.error) {
+  console.error(`Failed to load ${envPath}:`, result.error);
+} else {
+  console.log(`Loaded environment variables from ${envPath} inside loadEnv`);
+}

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
-import * as dotenv from 'dotenv';
-dotenv.config(); //dotenv configuration
+import './loadEnv.js';
 import './schedulers/updateScores.js'; //cron job for updating scores
 import { loadEnums } from './utils/dynamicEnums.js';
 
@@ -40,25 +39,10 @@ import path from 'path'; //
 // Determine the environment
 const env = process.env.NODE_ENV || 'development';
 
-// Explicitly load .env.<environment> first
-const envPath = path.resolve(process.cwd(), `.env.${env}`);
-const result = dotenv.config({ path: envPath });
-
-if (result.error) {
-  console.error(`Failed to load ${envPath}:`, result.error);
-} else {
-  console.log(`Loaded environment variables from ${envPath}`);
-}
-
 // define Variables
 const PROD_URL = process.env.PROD_URL;
 const FRONT_URL = env === 'production' ? PROD_URL : process.env.DEV_URL;
 const SERVER_URL = env === 'production' ? PROD_URL : process.env.DEV_URL_SERVER;
-
-//setting up access to .env and loading the corresponding .env file
-dotenv.config({
-  path: path.resolve(process.cwd(), `.env.${env}`),
-}); // loading environment variables
 
 cloudinary.config({
   cloud_name: process.env.CLOUD_NAME,


### PR DESCRIPTION
### Summary
This PR fixes two major bugs encountered when running the application inside a Docker container: relative assets failing to load due to Same-Origin/CORS restrictions, and a startup server error caused by environment variables being loaded after module imports had executed.

### Detailed Changes

#### 1. Fix Same-Origin Asset Loading Blocks
* **Files modified**: [urlHelper.js](file:///Users/chase/github/trendflow/client/src/utils/urlHelper.js)
* **Problem**: In production/Docker environments, the frontend was compiled with `FRONTEND_BASE_URL` set to the production site (`https://trendflowai.com`). Prepending this to assets caused local client builds to request SVG icons from the production domain, triggering `net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin` errors. Internal navigation links also redirected to the live production server.
* **Fix**: Updated `getFullIconUrl` and `getFullTrendUrl` to return root-relative paths. This allows the host origin (e.g. `http://localhost:5100` or any staging URL) to correctly serve the local assets same-origin and keeps internal links pointing to the current application instance.

#### 2. Fix ESM Environment Loading Race Condition
* **Files modified/added**: 
  - [loadEnv.js](file:///Users/chase/github/trendflow/loadEnv.js) (NEW)
  - [server.js](file:///Users/chase/github/trendflow/server.js)
  - [Dockerfile](file:///Users/chase/github/trendflow/Dockerfile)
* **Problem**: ES module imports are statically hoisted and run before top-level inline code. Because environment variables were configured inline in `server.js` (around line 45), early imports (such as routers loading the profanity validator) would execute with `process.env` completely undefined. This caused `utils/blacklisted.js` to attempt a fetch using `axios.get(undefined)`, crashing with `Invalid URL`.
* **Fix**:
  - Extracted environment loading to [loadEnv.js](file:///Users/chase/github/trendflow/loadEnv.js).
  - Imported `loadEnv.js` as the very first line of [server.js](file:///Users/chase/github/trendflow/server.js) to leverage ESM graph traversal rules, ensuring environment variables are populated prior to any subsequent module executions.
  - Updated the runner stage of the [Dockerfile](file:///Users/chase/github/trendflow/Dockerfile) to copy the new `loadEnv.js` file into the runtime bundle.